### PR TITLE
Implement list operations on TextParser

### DIFF
--- a/ogm/parser.py
+++ b/ogm/parser.py
@@ -38,6 +38,9 @@ class TextParser:
         else:
             return self.data[self._index]
 
+    def __reversed__(self):
+        return self.data[::-1]
+
     def parse_file(self, filepath, sheet=0, encoding="utf8", pdf_append=True):
         """
         Parse supported file types.

--- a/ogm/parser.py
+++ b/ogm/parser.py
@@ -25,6 +25,18 @@ class TextParser:
         self.corpus = None
         self.earliest_data = None
         self.has_datetime = None
+        self._index = -1
+
+    def __iter__(self):
+        return self
+
+    def __next__(self):
+        self._index += 1
+        if self._index >= len(self.data):
+            self._index = -1
+            raise StopIteration
+        else:
+            return self.data[self._index]
 
     def parse_file(self, filepath, sheet=0, encoding="utf8", pdf_append=True):
         """

--- a/ogm/parser.py
+++ b/ogm/parser.py
@@ -41,6 +41,9 @@ class TextParser:
     def __reversed__(self):
         return self.data[::-1]
 
+    def __getitem__(self, ind):
+        return self.data[ind]
+
     def parse_file(self, filepath, sheet=0, encoding="utf8", pdf_append=True):
         """
         Parse supported file types.


### PR DESCRIPTION
Closes #11 

Makes the `TextParser` object work a lot like a list: it can be indexed, reversed, or iterated through. The `self.data` attribute _is_ a list, and these operations could be done on it before, but now can be done directly on the `TextParser` object.