### PR TITLE
Implement self.data hashability

### DIFF
--- a/ogm/parser.py
+++ b/ogm/parser.py
@@ -28,6 +28,7 @@ class TextParser:
         self._index = -1
         self._hashing = None
         self._hashkey = None
+        self._keytype = None
 
     def __iter__(self):
         return self
@@ -49,10 +50,10 @@ class TextParser:
         """
         if isinstance(ind, int):
             return self.data[ind]
-        elif type(ind) is type(self._hashkey) and not self._hashing is None:
-            return self._hashing[ind]
+        elif type(ind) is self._keytype and not self._hashing is None:
+            return self.data[self._hashing[ind]]
         else:
-            raise KeyError("Unknown TextParser subscript received:", ind)
+            raise KeyError("Unknown TextParser subscript received: " + str(ind))
 
     def set_data_id(self, new_key):
         """
@@ -182,8 +183,10 @@ class TextParser:
         if id_key is not None:
             if isinstance(self.data[0][id_key], int):
                 self._hashing = {float(x[id_key]): i for i, x in enumerate(self.data)}
+                self._keytype = float
             else:
                 self._hashing = {x[id_key]: i for i, x in enumerate(self.data)}
+                self._keytype = type(self.data[0][id_key])
             self._hashkey = id_key
 
     def import_self(self, inpath="./output.pkl"):

--- a/ogm/parser.py
+++ b/ogm/parser.py
@@ -44,6 +44,9 @@ class TextParser:
         return self.data[::-1]
 
     def __getitem__(self, ind):
+        """
+        If subscripting with an int, it will be treated as a list index in `self.data`.
+        """
         if isinstance(ind, int):
             return self.data[ind]
         elif type(ind) is type(self._hashkey) and not self._hashing is None:
@@ -177,7 +180,10 @@ class TextParser:
             raise IOError("Unsupported file type")
 
         if id_key is not None:
-            self._hashing = {x[id_key]: i for i, x in enumerate(self.data)}
+            if isinstance(self.data[0][id_key], int):
+                self._hashing = {float(x[id_key]): i for i, x in enumerate(self.data)}
+            else:
+                self._hashing = {x[id_key]: i for i, x in enumerate(self.data)}
             self._hashkey = id_key
 
     def import_self(self, inpath="./output.pkl"):

--- a/ogm/parser.py
+++ b/ogm/parser.py
@@ -55,14 +55,18 @@ class TextParser:
         else:
             raise KeyError("Unknown TextParser subscript received: " + str(ind))
 
-    def set_data_id(self, new_key):
+    def set_data_id(self, id_key):
         """
-        It is unsafe to make the `new_key` an int, since it will be indistinguishable from a list index.
+        It is unsafe to make the `id_key` an int, since it will be indistinguishable from a list index.
+        Setter will automatically make `id_key` a float if it's an int.
         """
-        if isinstance(new_key, int):
-            raise TypeError("Hash keys should not be ints")
-
-        self._hashkey = new_key
+        if isinstance(self.data[0][id_key], int):
+            self._hashing = {float(x[id_key]): i for i, x in enumerate(self.data)}
+            self._keytype = float
+        else:
+            self._hashing = {x[id_key]: i for i, x in enumerate(self.data)}
+            self._keytype = type(self.data[0][id_key])
+        self._hashkey = id_key
 
     def parse_file(
         self, filepath, sheet=0, encoding="utf8", pdf_append=True, id_key=None


### PR DESCRIPTION
Closes #13 

Adds the `self._hashing` index structure: a `dict` mapping unique IDs to `self.data` indices. These unique IDs can be set by referencing their key (column header in the parsed data file) in `parse_file` or later in `set_data_id`.